### PR TITLE
Fixes GH render action

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -90,11 +90,15 @@ hexwall <- function(path,
   sticker_files <- rep_len(sticker_files, n_stickers)
   stickers <- file.path(path, sticker_files) %>%
     map(function(path) {
-      switch(tools::file_ext(path),
+      intermediate <- switch(tools::file_ext(path),
         svg = image_read_svg(path),
         pdf = image_read_pdf(path),
         image_read(path)
       )
+      # Scale down to avoid cache exhausted errors
+      result <- image_resize(intermediate, "400x400")
+      image_destroy(intermediate)
+      result
     }) %>%
     map(image_transparent, "white") %>%
     map(image_trim) %>%


### PR DESCRIPTION
- May indirectly fix #28 

![image](https://github.com/insightsengineering/hex-stickers/assets/211358/c9a82a2d-b398-4e9e-b50c-324fcaed9800)


Given that the hexwall is very small (less than 1000px), the best solution seems to be to scale down the individual hexes to prevent the cache from being exhausted.

The "400x400" scales down using the existing aspect ratio (according to `image_resize` documentation).

note: the `invoke` to `exec` modification is due to a deprecation warning with `purrr` see `?purrr::invoke`

### How to test it?

Trigger the workflow on this branch (beware that the hexwall and thumbs content will change)